### PR TITLE
Fix adapter config schema

### DIFF
--- a/src/main/resources/adapter_config_schema.json
+++ b/src/main/resources/adapter_config_schema.json
@@ -165,10 +165,10 @@
           "description": "Token for HTTP bearer authentication"
         }
       },
-      "baseId": {
-        "type": "string"
-      },
       "required": ["url"]
+    },
+    "baseId": {
+      "type": "string"
     },
     "subjectQuery": {
       "type": "object",


### PR DESCRIPTION
There were some issues with the adapter schema file:

* URL in `$id` returned 404
* `baseId` definition was broken