### PR TITLE
Disable warnings when loading profiles

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,4 +9,6 @@
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
+
+    <logger name="ca.uhn.fhir.context.support.DefaultProfileValidationSupport" level="ERROR" />
 </configuration>


### PR DESCRIPTION
This will hide the following warnings:

```txt
WARN  c.u.f.c.s.DefaultProfileValidationSupport - Unable to load resource: /org/hl7/fhir/r4/model/profile/profiles-resources.xml
WARN  c.u.f.c.s.DefaultProfileValidationSupport - Unable to load resource: /org/hl7/fhir/r4/model/profile/profiles-types.xml
WARN  c.u.f.c.s.DefaultProfileValidationSupport - Unable to load resource: /org/hl7/fhir/r4/model/profile/profiles-others.xml
WARN  c.u.f.c.s.DefaultProfileValidationSupport - Unable to load resource: /org/hl7/fhir/r4/model/extension/extension-definitions.xml
```