### PR TITLE
140 add time mappings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.4.14</version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>care.smith.top</groupId>
 	<artifactId>top-phenotypic-query</artifactId>
-	<version>0.8.8</version>
+	<version>1.0.0</version>
 	<name>TOP Phenotypic Query</name>
 
     <properties>

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -62,7 +62,8 @@ phenotypeQueries:
       SELECT 
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
         COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime) AS startDateTime,
-        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) AS endDateTime
+        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) AS endDateTime,
+        COALESCE(con.con_onsetdatetime, con.con_recordeddate) AS dateTime,
       FROM
         db2dataprocessor_out.v_condition con
       WHERE
@@ -74,16 +75,20 @@ phenotypeQueries:
         COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) IS NULL
         OR COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) {operator} {value}
       )
+    dateTimeIntervalPart: |
+      AND COALESCE(con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
+      dateTime: dateTime
   procedure:
     baseQuery: |
       SELECT 
           SUBSTRING(proc.proc_encounter_calculated_ref FROM 11) AS enc_id,
           COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) AS startDateTime,
-          COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) AS endDateTime 
+          COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) AS endDateTime,
+          proc.proc_performeddatetime as dateTime
       FROM 
           db2dataprocessor_out.v_procedure proc
       WHERE 
@@ -95,10 +100,13 @@ phenotypeQueries:
             COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) IS NULL 
             OR COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) {operator} {value}
         )
+    dateTimeIntervalPart: |
+      AND proc.proc_performeddatetime {operator} {value}
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
+      dateTime: dateTime
   medication:
     union: [ medication_administration, medication_statement, medication_request ]
   medication_administration:
@@ -106,7 +114,8 @@ phenotypeQueries:
       SELECT 
           SUBSTRING(medadm.medadm_encounter_calculated_ref FROM 11) AS enc_id,
           COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) AS startDateTime,
-          COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) AS endDateTime 
+          COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) AS endDateTime,
+          medadm.medadm_effectivedatetime AS dateTime
       FROM 
           db2dataprocessor_out.v_medicationadministration medadm
       INNER JOIN 
@@ -121,16 +130,20 @@ phenotypeQueries:
             COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) IS NULL 
             OR COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) {operator} {value}
         )
+    dateTimeIntervalPart: |
+        AND medadm.medadm_effectivedatetime {operator} {value}"
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
+      dateTime: dateTime
   medication_statement:
     baseQuery: |
       SELECT 
           SUBSTRING(medstat.medstat_encounter_calculated_ref FROM 11) AS enc_id,
           COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) AS startDateTime,
-          COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) AS endDateTime 
+          COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) AS endDateTime,
+          medstat.medstat_effectivedatetime as dateTime
       FROM 
           db2dataprocessor_out.v_medicationstatement medstat
       INNER JOIN 
@@ -145,10 +158,13 @@ phenotypeQueries:
             COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) IS NULL 
             OR COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) {operator} {value}
         )
+    dateTimeIntervalPart: |
+        medstat.medstat_effectivedatetime {operator} {value}
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
+      dateTime: dateTime
   medication_request:
     baseQuery: "SELECT SUBSTRING(medreq_encounter_calculated_ref FROM 11) AS enc_id, medreq_authoredon AS datetime FROM db2dataprocessor_out.v_medicationrequest, db2dataprocessor_out.v_medication\nWHERE medreq_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
     dateTimeIntervalPart: "\nAND medreq_authoredon {operator} {value}"

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -49,7 +49,7 @@ phenotypeQueries:
       startDateTime: enc_period_start
       endDateTime: enc_period_end
   observation:
-    baseQuery: "SELECT RIGHT(obs_encounter_calculated_ref, LENGTH(obs_encounter_calculated_ref) - 10) AS enc_id, obs_effectivedatetime, obs_valuequantity_value FROM db2dataprocessor_out.v_observation\nWHERE obs_valuequantity_value IS NOT NULL AND obs_code_system || '|' || obs_code_code IN ({codes})"
+    baseQuery: "SELECT SUBSTRING(obs_encounter_calculated_ref FROM 11) AS enc_id, obs_effectivedatetime, obs_valuequantity_value FROM db2dataprocessor_out.v_observation\nWHERE obs_valuequantity_value IS NOT NULL AND obs_code_system || '|' || obs_code_code IN ({codes})"
     numberValueIntervalPart: "\nAND obs_valuequantity_value {operator} {value}"
     numberValueListPart: "\nAND obs_valuequantity_value IN ({values})"
     dateTimeIntervalPart: "\nAND obs_effectivedatetime {operator} {value}"
@@ -58,33 +58,99 @@ phenotypeQueries:
       numberValue: obs_valuequantity_value
       dateTime: obs_effectivedatetime
   condition:
-    baseQuery: "SELECT RIGHT(con_encounter_calculated_ref, LENGTH(con_encounter_calculated_ref) - 10) AS enc_id,  con_recordeddate FROM db2dataprocessor_out.v_condition\nWHERE con_code_system || '|' || con_code_code IN ({codes})"
-    dateTimeIntervalPart: "\nAND con_recordeddate {operator} {value}"
+    baseQuery: |
+      SELECT 
+        SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
+        COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime) AS startDateTime,
+        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) AS endDateTime
+      FROM
+        db2dataprocessor_out.v_condition con
+      WHERE
+        con_code_system || '|' || con_code_code IN ({codes})
+    startDateTimeIntervalPart: |
+      AND COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime) {operator} {value}
+    endDateTimeIntervalPart: |
+      AND (
+        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) IS NULL
+        OR COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) {operator} {value}
+      )
     output:
       subject: enc_id
-      dateTime: con_recordeddate
+      startDateTime: startDateTime
+      endDateTime: endDateTime
   procedure:
-    baseQuery: "SELECT RIGHT(proc_encounter_calculated_ref, LENGTH(proc_encounter_calculated_ref) - 10) AS enc_id, proc_performeddatetime FROM db2dataprocessor_out.v_procedure\nWHERE proc_code_system || '|' || proc_code_code IN ({codes})"
-    dateTimeIntervalPart: "\nAND proc_performeddatetime {operator} {value}"
+    baseQuery: |
+      SELECT 
+          SUBSTRING(proc.proc_encounter_calculated_ref FROM 11) AS enc_id,
+          COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) AS startDateTime,
+          COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) AS endDateTime 
+      FROM 
+          db2dataprocessor_out.v_procedure proc
+      WHERE 
+      	proc_code_system || '|' || proc_code_code IN ({codes})
+    startDateTimeIntervalPart: |
+        AND COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) {operator} {value}
+    endDateTimeIntervalPart: |
+        AND (
+            COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) IS NULL 
+            OR COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) {operator} {value}
+        )
     output:
       subject: enc_id
-      dateTime: proc_performeddatetime
+      startDateTime: startDateTime
+      endDateTime: endDateTime
   medication:
     union: [ medication_administration, medication_statement, medication_request ]
   medication_administration:
-    baseQuery: "SELECT RIGHT(medadm_encounter_calculated_ref, LENGTH(medadm_encounter_calculated_ref) - 10) AS enc_id, medadm_effectivedatetime AS datetime FROM db2dataprocessor_out.v_medicationadministration, db2dataprocessor_out.v_medication\nWHERE medadm_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
-    dateTimeIntervalPart: "\nAND medadm_effectivedatetime {operator} {value}"
+    baseQuery: |
+      SELECT 
+          SUBSTRING(medadm.medadm_encounter_calculated_ref FROM 11) AS enc_id,
+          COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) AS startDateTime,
+          COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) AS endDateTime 
+      FROM 
+          db2dataprocessor_out.v_medicationadministration medadm
+      INNER JOIN 
+          db2dataprocessor_out.v_medication med 
+          ON medadm.medadm_medicationreference_ref = 'Medication/' || med.med_id
+      WHERE 
+          med.med_code_system || '|' || med.med_code_code IN ({codes})
+    startDateTimeIntervalPart: |
+        AND COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) {operator} {value}
+    endDateTimeIntervalPart: |
+        AND (
+            COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) IS NULL 
+            OR COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) {operator} {value}
+        )
     output:
       subject: enc_id
-      dateTime: datetime
+      startDateTime: startDateTime
+      endDateTime: endDateTime
   medication_statement:
-    baseQuery: "SELECT RIGHT(medstat_encounter_calculated_ref, LENGTH(medstat_encounter_calculated_ref) - 10) AS enc_id, medstat_effectivedatetime AS datetime FROM db2dataprocessor_out.v_medicationstatement, db2dataprocessor_out.v_medication\nWHERE medstat_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
-    dateTimeIntervalPart: "\nAND medstat_effectivedatetime {operator} {value}"
+    baseQuery: |
+      SELECT 
+          SUBSTRING(medstat.medstat_encounter_calculated_ref FROM 11) AS enc_id,
+          COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) AS startDateTime,
+          COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) AS endDateTime 
+      FROM 
+          db2dataprocessor_out.v_medicationstatement medstat
+      INNER JOIN 
+          db2dataprocessor_out.v_medication med 
+          ON medstat.medstat_medicationreference_ref = 'Medication/' || med.med_id
+      WHERE 
+          med.med_code_system || '|' || med.med_code_code IN ({codes})
+    startDateTimeIntervalPart: |
+        AND COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) {operator} {value}
+    endDateTimeIntervalPart: |
+        AND (
+            COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) IS NULL 
+            OR COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) {operator} {value}
+        )
     output:
       subject: enc_id
-      dateTime: datetime
+      startDateTime: startDateTime
+      endDateTime: endDateTime
   medication_request:
-    baseQuery: "SELECT RIGHT(medreq_encounter_calculated_ref, LENGTH(medreq_encounter_calculated_ref) - 10) AS enc_id, medreq_authoredon AS datetime FROM db2dataprocessor_out.v_medicationrequest, db2dataprocessor_out.v_medication\nWHERE medreq_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
+    baseQuery: "SELECT SUBSTRING(medreq_encounter_calculated_ref FROM 11) AS enc_id, medreq_authoredon AS datetime FROM db2dataprocessor_out.v_medicationrequest, db2dataprocessor_out.v_medication\nWHERE medreq_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
     dateTimeIntervalPart: "\nAND medreq_authoredon {operator} {value}"
     output:
       subject: enc_id

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -61,34 +61,29 @@ phenotypeQueries:
     baseQuery: |
       SELECT 
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
-        COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime) AS startDateTime,
-        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) AS endDateTime,
-        COALESCE(con.con_onsetdatetime, con.con_recordeddate) AS dateTime,
+        COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime, con.con_recordeddate) AS startDateTime,
+        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) AS endDateTime
       FROM
         db2dataprocessor_out.v_condition con
       WHERE
         con_code_system || '|' || con_code_code IN ({codes})
     startDateTimeIntervalPart: |
-      AND COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime) {operator} {value}
+      AND COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
     endDateTimeIntervalPart: |
       AND (
-        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) IS NULL
-        OR COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime) {operator} {value}
+        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) IS NULL
+        OR COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
       )
-    dateTimeIntervalPart: |
-      AND COALESCE(con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
-      dateTime: dateTime
   procedure:
     baseQuery: |
       SELECT 
           SUBSTRING(proc.proc_encounter_calculated_ref FROM 11) AS enc_id,
           COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) AS startDateTime,
-          COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) AS endDateTime,
-          proc.proc_performeddatetime as dateTime
+          COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) AS endDateTime
       FROM 
           db2dataprocessor_out.v_procedure proc
       WHERE 
@@ -100,13 +95,10 @@ phenotypeQueries:
             COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) IS NULL 
             OR COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) {operator} {value}
         )
-    dateTimeIntervalPart: |
-      AND proc.proc_performeddatetime {operator} {value}
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
-      dateTime: dateTime
   medication:
     union: [ medication_administration, medication_statement, medication_request ]
   medication_administration:
@@ -114,8 +106,7 @@ phenotypeQueries:
       SELECT 
           SUBSTRING(medadm.medadm_encounter_calculated_ref FROM 11) AS enc_id,
           COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) AS startDateTime,
-          COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) AS endDateTime,
-          medadm.medadm_effectivedatetime AS dateTime
+          COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) AS endDateTime
       FROM 
           db2dataprocessor_out.v_medicationadministration medadm
       INNER JOIN 
@@ -130,20 +121,16 @@ phenotypeQueries:
             COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) IS NULL 
             OR COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) {operator} {value}
         )
-    dateTimeIntervalPart: |
-        AND medadm.medadm_effectivedatetime {operator} {value}"
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
-      dateTime: dateTime
   medication_statement:
     baseQuery: |
       SELECT 
           SUBSTRING(medstat.medstat_encounter_calculated_ref FROM 11) AS enc_id,
           COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) AS startDateTime,
-          COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) AS endDateTime,
-          medstat.medstat_effectivedatetime as dateTime
+          COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) AS endDateTime
       FROM 
           db2dataprocessor_out.v_medicationstatement medstat
       INNER JOIN 
@@ -158,13 +145,10 @@ phenotypeQueries:
             COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) IS NULL 
             OR COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) {operator} {value}
         )
-    dateTimeIntervalPart: |
-        medstat.medstat_effectivedatetime {operator} {value}
     output:
       subject: enc_id
       startDateTime: startDateTime
       endDateTime: endDateTime
-      dateTime: dateTime
   medication_request:
     baseQuery: "SELECT SUBSTRING(medreq_encounter_calculated_ref FROM 11) AS enc_id, medreq_authoredon AS datetime FROM db2dataprocessor_out.v_medicationrequest, db2dataprocessor_out.v_medication\nWHERE medreq_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
     dateTimeIntervalPart: "\nAND medreq_authoredon {operator} {value}"

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -63,10 +63,12 @@ phenotypeQueries:
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
         con.con_onsetperiod_start AS startDateTime, con.con_onsetperiod_end AS endDateTime, con_onsetdatetime, con_recordeddate,
         CASE
-          WHEN con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL AND con.con_onsetdatetime IS NULL
-            THEN con.con_recordeddate
-          ELSE
-            con.con_onsetdatetime
+          WHEN con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL
+            THEN
+              CASE WHEN con.con_onsetdatetime IS NULL
+                THEN con.con_recordeddate
+                ELSE con.con_onsetdatetime
+           END
         END
         AS dateTime
       FROM

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -59,21 +59,40 @@ phenotypeQueries:
       dateTime: obs_effectivedatetime
   condition:
     baseQuery: |
-      SELECT 
+      SELECT
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
-        COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime, con.con_recordeddate) AS startDateTime,
-        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) AS endDateTime
+        con.con_onsetperiod_start AS startDateTime, con.con_onsetperiod_end AS endDateTime, con_onsetdatetime, con_recordeddate,
+        CASE
+          WHEN con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL AND con.con_onsetdatetime IS NULL
+            THEN con.con_recordeddate
+          ELSE
+            con.con_onsetdatetime
+        END
+        AS dateTime
       FROM
         db2dataprocessor_out.v_condition con
       WHERE
         con_code_system || '|' || con_code_code IN ({codes})
     startDateTimeIntervalPart: |
-      AND COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+      AND
+      CASE
+      WHEN con.con_onsetperiod_start IS NOT NULL
+        THEN con.con_onsetperiod_start {operator} {value}
+      WHEN con.con_onsetperiod_end IS NOT NULL
+        THEN true
+      ELSE
+        COALESCE(con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+      END
     endDateTimeIntervalPart: |
-      AND (
-        COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) IS NULL
-        OR COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
-      )
+      AND
+      CASE
+      WHEN con.con_onsetperiod_end IS NOT NULL
+        THEN con.con_onsetperiod_end {operator} {value}
+      WHEN con.con_onsetperiod_start IS NOT NULL
+        THEN true
+      ELSE
+        COALESCE(con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+      END
     output:
       subject: enc_id
       startDateTime: startDateTime

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -76,22 +76,16 @@ phenotypeQueries:
     startDateTimeIntervalPart: |
       AND
       CASE
-      WHEN con.con_onsetperiod_start IS NOT NULL
-        THEN con.con_onsetperiod_start {operator} {value}
-      WHEN con.con_onsetperiod_end IS NOT NULL
-        THEN true
-      ELSE
-        COALESCE(con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+        WHEN con.con_onsetperiod_start IS NOT NULL OR (con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL)
+          THEN COALESCE(con.con_onsetperiod_start, con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+        ELSE true
       END
     endDateTimeIntervalPart: |
       AND
       CASE
-      WHEN con.con_onsetperiod_end IS NOT NULL
-        THEN con.con_onsetperiod_end {operator} {value}
-      WHEN con.con_onsetperiod_start IS NOT NULL
-        THEN true
-      ELSE
-        COALESCE(con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+        WHEN con.con_onsetperiod_end IS NOT NULL OR (con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL)
+          THEN COALESCE(con.con_onsetperiod_end, con.con_onsetdatetime, con.con_recordeddate) {operator} {value}
+        ELSE true
       END
     output:
       subject: enc_id

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -63,7 +63,12 @@ phenotypeQueries:
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
         con.con_onsetperiod_start AS start_date_time,
         con.con_onsetperiod_end AS end_date_time,
-        COALESCE(con.con_onsetdatetime, con.con_recordeddate) AS date_time 
+        CASE
+          WHEN con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL AND con.con_onsetdatetime IS NULL
+          THEN con.con_recordeddate
+          ELSE con.con_onsetdatetime
+        END
+        AS date_time 
       FROM
         db2dataprocessor_out.v_condition con
       WHERE

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -61,7 +61,7 @@ phenotypeQueries:
     baseQuery: |
       SELECT
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
-        con.con_onsetperiod_start AS startDateTime, con.con_onsetperiod_end AS endDateTime, con_onsetdatetime, con_recordeddate,
+        con.con_onsetperiod_start AS start_date_time, con.con_onsetperiod_end AS end_date_time, con_onsetdatetime, con_recordeddate,
         CASE
           WHEN con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL
             THEN
@@ -70,7 +70,7 @@ phenotypeQueries:
                 ELSE con.con_onsetdatetime
            END
         END
-        AS dateTime
+        AS date_time
       FROM
         db2dataprocessor_out.v_condition con
       WHERE
@@ -91,79 +91,123 @@ phenotypeQueries:
       END
     output:
       subject: enc_id
-      startDateTime: startDateTime
-      endDateTime: endDateTime
+      startDateTime: start_date_time
+      endDateTime: end_date_time
+      dateTime: date_time
   procedure:
     baseQuery: |
       SELECT 
           SUBSTRING(proc.proc_encounter_calculated_ref FROM 11) AS enc_id,
-          COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) AS startDateTime,
-          COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) AS endDateTime
+          proc.proc_performedperiod_start AS start_date_time,
+          proc.proc_performedperiod_end AS end_date_time,
+          CASE
+          	WHEN proc.proc_performedperiod_start IS NULL AND proc.proc_performedperiod_end IS NULL
+          	THEN proc.proc_performeddatetime
+          END
+          AS date_time
       FROM 
           db2dataprocessor_out.v_procedure proc
       WHERE 
       	proc_code_system || '|' || proc_code_code IN ({codes})
     startDateTimeIntervalPart: |
-        AND COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) {operator} {value}
+        AND 
+          CASE
+            WHEN proc.proc_performedperiod_start IS NOT NULL OR (proc.proc_performedperiod_start IS NULL AND proc.proc_performedperiod_end IS NULL)
+              THEN COALESCE(proc.proc_performedperiod_start, proc.proc_performeddatetime) {operator} {value}
+            ELSE true
+          END
     endDateTimeIntervalPart: |
-        AND (
-            COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) IS NULL 
-            OR COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) {operator} {value}
-        )
+        AND
+          CASE
+            WHEN proc.proc_performedperiod_end IS NOT NULL OR (proc.proc_performedperiod_start IS NULL AND proc.proc_performedperiod_end IS NULL)
+              THEN COALESCE(proc.proc_performedperiod_end, proc.proc_performeddatetime) {operator} {value}
+            ELSE true
+          END
     output:
       subject: enc_id
-      startDateTime: startDateTime
-      endDateTime: endDateTime
+      startDateTime: start_date_time
+      endDateTime: end_date_time
+      dateTime: date_time
   medication:
     union: [ medication_administration, medication_statement, medication_request ]
   medication_administration:
     baseQuery: |
-      SELECT 
+      SELECT
           SUBSTRING(medadm.medadm_encounter_calculated_ref FROM 11) AS enc_id,
-          COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) AS startDateTime,
-          COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) AS endDateTime
-      FROM 
-          db2dataprocessor_out.v_medicationadministration medadm
-      INNER JOIN 
-          db2dataprocessor_out.v_medication med 
-          ON medadm.medadm_medicationreference_ref = 'Medication/' || med.med_id
-      WHERE 
-          med.med_code_system || '|' || med.med_code_code IN ({codes})
+          medadm.medadm_effectiveperiod_start AS start_date_time,
+          medadm.medadm_effectiveperiod_end AS end_date_time,
+          medadm.medadm_medicationreference_ref,
+          med.med_code_system,
+          med.med_code_code,
+          CASE
+          	WHEN medadm.medadm_effectiveperiod_start IS NULL AND medadm.medadm_effectiveperiod_end IS NULL
+          	THEN medadm.medadm_effectivedatetime
+          END
+          AS date_time
+      FROM
+          db2dataprocessor_out.v_medicationadministration medadm,
+          db2dataprocessor_out.v_medication med
+      WHERE
+          medadm.medadm_medicationreference_ref = 'Medication/' || med.med_id
+          AND med.med_code_system || '|' || med.med_code_code IN ({codes})
     startDateTimeIntervalPart: |
-        AND COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) {operator} {value}
+          AND
+            CASE
+              WHEN medadm.medadm_effectiveperiod_start IS NOT NULL OR (medadm.medadm_effectiveperiod_start IS NULL AND medadm.medadm_effectiveperiod_end IS NULL)
+                THEN COALESCE(medadm.medadm_effectiveperiod_start, medadm.medadm_effectivedatetime) {operator} {value}
+              ELSE true
+            END
     endDateTimeIntervalPart: |
-        AND (
-            COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) IS NULL 
-            OR COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) {operator} {value}
-        )
+          AND
+            CASE
+              WHEN medadm.medadm_effectiveperiod_end IS NOT NULL OR (medadm.medadm_effectiveperiod_start IS NULL AND medadm.medadm_effectiveperiod_end IS NULL)
+                THEN COALESCE(medadm.medadm_effectiveperiod_end, medadm.medadm_effectivedatetime) {operator} {value}
+              ELSE true
+            END
     output:
       subject: enc_id
-      startDateTime: startDateTime
-      endDateTime: endDateTime
+      startDateTime: start_date_time
+      endDateTime: end_date_time
+      dateTime: date_time
   medication_statement:
     baseQuery: |
-      SELECT 
+      SELECT
           SUBSTRING(medstat.medstat_encounter_calculated_ref FROM 11) AS enc_id,
-          COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) AS startDateTime,
-          COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) AS endDateTime
-      FROM 
-          db2dataprocessor_out.v_medicationstatement medstat
-      INNER JOIN 
-          db2dataprocessor_out.v_medication med 
-          ON medstat.medstat_medicationreference_ref = 'Medication/' || med.med_id
-      WHERE 
-          med.med_code_system || '|' || med.med_code_code IN ({codes})
+          medstat.medstat_effectiveperiod_start AS start_date_time,
+          medstat.medstat_effectiveperiod_end AS end_date_time,
+          medstat.medstat_medicationreference_ref,
+          med.med_code_system,
+          med.med_code_code,
+          CASE
+          	WHEN medstat.medstat_effectiveperiod_start IS NULL AND medstat.medstat_effectiveperiod_end IS NULL
+          	THEN medstat.medstat_effectivedatetime
+          END
+          AS date_time
+      FROM
+          db2dataprocessor_out.v_medicationstatement medstat,
+          db2dataprocessor_out.v_medication med
+      WHERE
+          medstat.medstat_medicationreference_ref = 'Medication/' || med.med_id
+          AND med.med_code_system || '|' || med.med_code_code IN ({codes})
     startDateTimeIntervalPart: |
-        AND COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) {operator} {value}
+      AND
+        CASE
+          WHEN medstat.medstat_effectiveperiod_start IS NOT NULL OR (medstat.medstat_effectiveperiod_start IS NULL AND medstat.medstat_effectiveperiod_end IS NULL)
+            THEN COALESCE(medstat.medstat_effectiveperiod_start, medstat.medstat_effectivedatetime) {operator} {value}
+          ELSE true
+        END
     endDateTimeIntervalPart: |
-        AND (
-            COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) IS NULL 
-            OR COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) {operator} {value}
-        )
+      AND
+        CASE
+          WHEN medstat.medstat_effectiveperiod_end IS NOT NULL OR (medstat.medstat_effectiveperiod_start IS NULL AND medstat.medstat_effectiveperiod_end IS NULL)
+            THEN COALESCE(medstat.medstat_effectiveperiod_end, medstat.medstat_effectivedatetime) {operator} {value}
+          ELSE true
+        END
     output:
       subject: enc_id
-      startDateTime: startDateTime
-      endDateTime: endDateTime
+      startDateTime: start_date_time
+      endDateTime: end_date_time
+      dateTime: date_time
   medication_request:
     baseQuery: "SELECT SUBSTRING(medreq_encounter_calculated_ref FROM 11) AS enc_id, medreq_authoredon AS datetime FROM db2dataprocessor_out.v_medicationrequest, db2dataprocessor_out.v_medication\nWHERE medreq_medicationreference_ref = 'Medication/' || med_id AND med_code_system || '|' || med_code_code IN ({codes})"
     dateTimeIntervalPart: "\nAND medreq_authoredon {operator} {value}"

--- a/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
+++ b/src/main/resources/default_adapter_configuration/Default_Interpolar_Adapter.yml
@@ -61,16 +61,9 @@ phenotypeQueries:
     baseQuery: |
       SELECT
         SUBSTRING(con.con_encounter_calculated_ref FROM 11) AS enc_id,
-        con.con_onsetperiod_start AS start_date_time, con.con_onsetperiod_end AS end_date_time, con_onsetdatetime, con_recordeddate,
-        CASE
-          WHEN con.con_onsetperiod_start IS NULL AND con.con_onsetperiod_end IS NULL
-            THEN
-              CASE WHEN con.con_onsetdatetime IS NULL
-                THEN con.con_recordeddate
-                ELSE con.con_onsetdatetime
-           END
-        END
-        AS date_time
+        con.con_onsetperiod_start AS start_date_time,
+        con.con_onsetperiod_end AS end_date_time,
+        COALESCE(con.con_onsetdatetime, con.con_recordeddate) AS date_time 
       FROM
         db2dataprocessor_out.v_condition con
       WHERE
@@ -100,11 +93,7 @@ phenotypeQueries:
           SUBSTRING(proc.proc_encounter_calculated_ref FROM 11) AS enc_id,
           proc.proc_performedperiod_start AS start_date_time,
           proc.proc_performedperiod_end AS end_date_time,
-          CASE
-          	WHEN proc.proc_performedperiod_start IS NULL AND proc.proc_performedperiod_end IS NULL
-          	THEN proc.proc_performeddatetime
-          END
-          AS date_time
+          proc.proc_performeddatetime AS date_time
       FROM 
           db2dataprocessor_out.v_procedure proc
       WHERE 
@@ -136,14 +125,7 @@ phenotypeQueries:
           SUBSTRING(medadm.medadm_encounter_calculated_ref FROM 11) AS enc_id,
           medadm.medadm_effectiveperiod_start AS start_date_time,
           medadm.medadm_effectiveperiod_end AS end_date_time,
-          medadm.medadm_medicationreference_ref,
-          med.med_code_system,
-          med.med_code_code,
-          CASE
-          	WHEN medadm.medadm_effectiveperiod_start IS NULL AND medadm.medadm_effectiveperiod_end IS NULL
-          	THEN medadm.medadm_effectivedatetime
-          END
-          AS date_time
+          medadm.medadm_effectivedatetime AS date_time
       FROM
           db2dataprocessor_out.v_medicationadministration medadm,
           db2dataprocessor_out.v_medication med
@@ -175,14 +157,7 @@ phenotypeQueries:
           SUBSTRING(medstat.medstat_encounter_calculated_ref FROM 11) AS enc_id,
           medstat.medstat_effectiveperiod_start AS start_date_time,
           medstat.medstat_effectiveperiod_end AS end_date_time,
-          medstat.medstat_medicationreference_ref,
-          med.med_code_system,
-          med.med_code_code,
-          CASE
-          	WHEN medstat.medstat_effectiveperiod_start IS NULL AND medstat.medstat_effectiveperiod_end IS NULL
-          	THEN medstat.medstat_effectivedatetime
-          END
-          AS date_time
+          medstat.medstat_effectivedatetime AS date_time
       FROM
           db2dataprocessor_out.v_medicationstatement medstat,
           db2dataprocessor_out.v_medication med

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ConditionTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ConditionTest.java
@@ -1,5 +1,7 @@
 package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import care.smith.top.model.ItemType;
 import care.smith.top.model.Phenotype;
 import care.smith.top.top_phenotypic_query.result.ResultSet;
@@ -7,55 +9,65 @@ import care.smith.top.top_phenotypic_query.util.DateUtil;
 import care.smith.top.top_phenotypic_query.util.builder.Phe;
 import care.smith.top.top_phenotypic_query.util.builder.Que;
 import care.smith.top.top_phenotypic_query.util.builder.Res;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConditionTest {
-  
+
   private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
-  
+
   private static final Phenotype sex = new Phe("sex").itemType(ItemType.SUBJECT_SEX).string().get();
   private static final Phenotype male = new Phe("male").restriction(sex, Res.of("male")).get();
   private static final Phenotype age = new Phe("age").itemType(ItemType.SUBJECT_AGE).number().get();
   private static final Phenotype old = new Phe("old").restriction(age, Res.ge(60)).get();
-  
+
   private static final Phenotype con =
-          new Phe("con", "http://snomed.info/sct", "135816001", "258157001", "438949009")
-                  .itemType(ItemType.CONDITION)
-                  .bool()
-                  .get();
-  
+      new Phe("con", "http://snomed.info/sct", "135816001", "258157001", "438949009")
+          .itemType(ItemType.CONDITION)
+          .bool()
+          .get();
+
   static Arguments a(UnaryOperator<Que> restriction, String... expected) {
     return Arguments.of(restriction, Set.of(expected));
   }
-  
+
   static Stream<Arguments> data() {
     return Stream.of(
-            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
-                    "HOSP-0002-E2"),
-            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
-                    "HOSP-0003-E3"),
-            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
-                    "HOSP-0002-E2", "HOSP-0003-E3"),
-            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
-                    "HOSP-0004-E4"),
-            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
-                    "HOSP-0002-E2", "HOSP-0003-E3", "HOSP-0004-E4")
-    );
+        a(
+            q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
+            "HOSP-0002-E2",
+            "HOSP-0004-E4"),
+        a(
+            q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
+            "HOSP-0003-E3",
+            "HOSP-0004-E4"),
+        a(
+            q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
+            "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4"),
+        a(
+            q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
+            "HOSP-0004-E4"),
+        a(
+            q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
+            "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4"));
   }
-  
+
   @ParameterizedTest
   @MethodSource("data")
-  void condition(Function<Que, Que> restrictions, Set<String> expectedSubjectIds) throws InstantiationException {
-    ResultSet rs = restrictions.apply(new Que(CONFIG, con))
+  void condition(Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
+      throws InstantiationException {
+    ResultSet rs =
+        restrictions
+            .apply(new Que(CONFIG, con))
             .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/condition.sql")
             .execute();
     assertEquals(expectedSubjectIds, rs.getSubjectIds());

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ConditionTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ConditionTest.java
@@ -1,0 +1,63 @@
+package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
+
+import care.smith.top.model.ItemType;
+import care.smith.top.model.Phenotype;
+import care.smith.top.top_phenotypic_query.result.ResultSet;
+import care.smith.top.top_phenotypic_query.util.DateUtil;
+import care.smith.top.top_phenotypic_query.util.builder.Phe;
+import care.smith.top.top_phenotypic_query.util.builder.Que;
+import care.smith.top.top_phenotypic_query.util.builder.Res;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConditionTest {
+  
+  private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
+  
+  private static final Phenotype sex = new Phe("sex").itemType(ItemType.SUBJECT_SEX).string().get();
+  private static final Phenotype male = new Phe("male").restriction(sex, Res.of("male")).get();
+  private static final Phenotype age = new Phe("age").itemType(ItemType.SUBJECT_AGE).number().get();
+  private static final Phenotype old = new Phe("old").restriction(age, Res.ge(60)).get();
+  
+  private static final Phenotype con =
+          new Phe("con", "http://snomed.info/sct", "135816001", "258157001", "438949009")
+                  .itemType(ItemType.CONDITION)
+                  .bool()
+                  .get();
+  
+  static Arguments a(UnaryOperator<Que> restriction, String... expected) {
+    return Arguments.of(restriction, Set.of(expected));
+  }
+  
+  static Stream<Arguments> data() {
+    return Stream.of(
+            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
+                    "HOSP-0002-E2"),
+            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
+                    "HOSP-0003-E3"),
+            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
+                    "HOSP-0002-E2", "HOSP-0003-E3"),
+            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
+                    "HOSP-0004-E4"),
+            a(q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
+                    "HOSP-0002-E2", "HOSP-0003-E3", "HOSP-0004-E4")
+    );
+  }
+  
+  @ParameterizedTest
+  @MethodSource("data")
+  void condition(Function<Que, Que> restrictions, Set<String> expectedSubjectIds) throws InstantiationException {
+    ResultSet rs = restrictions.apply(new Que(CONFIG, con))
+            .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/condition.sql")
+            .execute();
+    assertEquals(expectedSubjectIds, rs.getSubjectIds());
+  }
+}

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ConditionTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ConditionTest.java
@@ -58,7 +58,15 @@ public class ConditionTest {
             q -> q.inc(con, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
             "HOSP-0002-E2",
             "HOSP-0003-E3",
-            "HOSP-0004-E4"));
+            "HOSP-0004-E4"),
+        a(q -> q.inc(con, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
+        a(
+            q -> q.inc(con, Res.le(DateUtil.parse("2026-04-05"))),
+            "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4",
+            "HOSP-0005-E5",
+            "HOSP-0006-E6"));
   }
 
   @ParameterizedTest

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
@@ -18,129 +18,144 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class MedicationTimeTest {
-  
+
   private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
-  
+
   private static final Phenotype medadm =
-          new Phe("medadm", "http://fhir.de/CodeSystem/bfarm/atc", "atc1", "atc2")
-                  .itemType(ItemType.MEDICATION_ADMINISTRATION)
-                  .bool()
-                  .get();
-  
+      new Phe("medadm", "http://fhir.de/CodeSystem/bfarm/atc", "atc1", "atc2")
+          .itemType(ItemType.MEDICATION_ADMINISTRATION)
+          .bool()
+          .get();
+
   private static final Phenotype medstmt =
-          new Phe("medstmt", "http://fhir.de/CodeSystem/bfarm/atc", "atc1", "atc2")
-                  .itemType(ItemType.MEDICATION_STATEMENT)
-                  .bool()
-                  .get();
-  
+      new Phe("medstmt", "http://fhir.de/CodeSystem/bfarm/atc", "atc1", "atc2")
+          .itemType(ItemType.MEDICATION_STATEMENT)
+          .bool()
+          .get();
+
   static Arguments a(Phenotype phe, UnaryOperator<Que> restriction, String... expected) {
     return Arguments.of(phe, restriction, Set.of(expected));
   }
-  
+
   static Stream<Arguments> data() {
     return Stream.of(
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-01"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0011-E-1",
-                    "HOSP-0012-E-1"),
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-02"), DateUtil.parse("2020-01-02"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0012-E-1",
-                    "HOSP-0014-E-1"),
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-02"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0011-E-1",
-                    "HOSP-0012-E-1",
-                    "HOSP-0014-E-1"),
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-03"), DateUtil.parse("2020-01-03"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0013-E-1",
-                    "HOSP-0014-E-1"),
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-03"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0011-E-1",
-                    "HOSP-0012-E-1",
-                    "HOSP-0013-E-1",
-                    "HOSP-0014-E-1"),
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.ge(DateUtil.parse("2020-01-03"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0013-E-1",
-                    "HOSP-0014-E-1",
-                    "HOSP-0015-E-1"),
-            a(
-                    medadm,
-                    q -> q.inc(medadm, Res.le(DateUtil.parse("2020-01-04"))),
-                    "HOSP-0004-E-1",
-                    "HOSP-0011-E-1",
-                    "HOSP-0012-E-1",
-                    "HOSP-0013-E-1",
-                    "HOSP-0014-E-1"),
-            
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-01"))),
-                    "HOSP-0031-E-1",
-                    "HOSP-0032-E-1"),
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-02"), DateUtil.parse("2020-01-02"))),
-                    "HOSP-0032-E-1",
-                    "HOSP-0034-E-1"),
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-02"))),
-                    "HOSP-0031-E-1",
-                    "HOSP-0032-E-1",
-                    "HOSP-0034-E-1"),
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-03"), DateUtil.parse("2020-01-03"))),
-                    "HOSP-0033-E-1",
-                    "HOSP-0034-E-1"),
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-03"))),
-                    "HOSP-0031-E-1",
-                    "HOSP-0032-E-1",
-                    "HOSP-0033-E-1",
-                    "HOSP-0034-E-1"),
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.ge(DateUtil.parse("2020-01-03"))),
-                    "HOSP-0033-E-1",
-                    "HOSP-0034-E-1",
-                    "HOSP-0035-E-1"),
-            a(
-                    medstmt,
-                    q -> q.inc(medstmt, Res.le(DateUtil.parse("2020-01-04"))),
-                    "HOSP-0031-E-1",
-                    "HOSP-0032-E-1",
-                    "HOSP-0033-E-1",
-                    "HOSP-0034-E-1")
-    );
+        a(
+            medadm,
+            q ->
+                q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-01"))),
+            "HOSP-0004-E-1",
+            "HOSP-0011-E-1",
+            "HOSP-0012-E-1"),
+        a(
+            medadm,
+            q ->
+                q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-02"), DateUtil.parse("2020-01-02"))),
+            "HOSP-0004-E-1",
+            "HOSP-0012-E-1",
+            "HOSP-0014-E-1"),
+        a(
+            medadm,
+            q ->
+                q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-02"))),
+            "HOSP-0004-E-1",
+            "HOSP-0011-E-1",
+            "HOSP-0012-E-1",
+            "HOSP-0014-E-1"),
+        a(
+            medadm,
+            q ->
+                q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-03"), DateUtil.parse("2020-01-03"))),
+            "HOSP-0004-E-1",
+            "HOSP-0013-E-1",
+            "HOSP-0014-E-1"),
+        a(
+            medadm,
+            q ->
+                q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-03"))),
+            "HOSP-0004-E-1",
+            "HOSP-0011-E-1",
+            "HOSP-0012-E-1",
+            "HOSP-0013-E-1",
+            "HOSP-0014-E-1"),
+        a(
+            medadm,
+            q -> q.inc(medadm, Res.ge(DateUtil.parse("2020-01-03"))),
+            "HOSP-0004-E-1",
+            "HOSP-0013-E-1",
+            "HOSP-0014-E-1",
+            "HOSP-0015-E-1"),
+        a(
+            medadm,
+            q -> q.inc(medadm, Res.le(DateUtil.parse("2020-01-04"))),
+            "HOSP-0004-E-1",
+            "HOSP-0011-E-1",
+            "HOSP-0012-E-1",
+            "HOSP-0013-E-1",
+            "HOSP-0014-E-1"),
+        a(
+            medstmt,
+            q ->
+                q.inc(
+                    medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-01"))),
+            "HOSP-0031-E-1",
+            "HOSP-0032-E-1"),
+        a(
+            medstmt,
+            q ->
+                q.inc(
+                    medstmt, Res.geLe(DateUtil.parse("2020-01-02"), DateUtil.parse("2020-01-02"))),
+            "HOSP-0032-E-1",
+            "HOSP-0034-E-1"),
+        a(
+            medstmt,
+            q ->
+                q.inc(
+                    medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-02"))),
+            "HOSP-0031-E-1",
+            "HOSP-0032-E-1",
+            "HOSP-0034-E-1"),
+        a(
+            medstmt,
+            q ->
+                q.inc(
+                    medstmt, Res.geLe(DateUtil.parse("2020-01-03"), DateUtil.parse("2020-01-03"))),
+            "HOSP-0033-E-1",
+            "HOSP-0034-E-1"),
+        a(
+            medstmt,
+            q ->
+                q.inc(
+                    medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-03"))),
+            "HOSP-0031-E-1",
+            "HOSP-0032-E-1",
+            "HOSP-0033-E-1",
+            "HOSP-0034-E-1"),
+        a(
+            medstmt,
+            q -> q.inc(medstmt, Res.ge(DateUtil.parse("2020-01-03"))),
+            "HOSP-0033-E-1",
+            "HOSP-0034-E-1",
+            "HOSP-0035-E-1"),
+        a(
+            medstmt,
+            q -> q.inc(medstmt, Res.le(DateUtil.parse("2020-01-04"))),
+            "HOSP-0031-E-1",
+            "HOSP-0032-E-1",
+            "HOSP-0033-E-1",
+            "HOSP-0034-E-1"));
   }
-  
+
   @ParameterizedTest
   @MethodSource("data")
-  void medicationAdministration(Phenotype phe, Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
-          throws InstantiationException {
+  void medicationAdministration(
+      Phenotype phe, Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
+      throws InstantiationException {
     ResultSet rs =
-            restrictions
-                    .apply(new Que(CONFIG, phe))
-                    .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/medication_time.sql")
-                    .execute();
+        restrictions
+            .apply(new Que(CONFIG, phe))
+            .executeSqlFromResources(
+                "INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/medication_time.sql")
+            .execute();
     assertEquals(expectedSubjectIds, rs.getSubjectIds());
   }
 }

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
@@ -1,0 +1,147 @@
+package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
+
+import care.smith.top.model.ItemType;
+import care.smith.top.model.Phenotype;
+import care.smith.top.top_phenotypic_query.result.ResultSet;
+import care.smith.top.top_phenotypic_query.util.DateUtil;
+import care.smith.top.top_phenotypic_query.util.builder.Phe;
+import care.smith.top.top_phenotypic_query.util.builder.Que;
+import care.smith.top.top_phenotypic_query.util.builder.Res;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MedicationTimeTest {
+  
+  private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
+  
+  private static final Phenotype medadm =
+          new Phe("medadm", "http://fhir.de/CodeSystem/bfarm/atc", "atc1", "atc2")
+                  .itemType(ItemType.MEDICATION_ADMINISTRATION)
+                  .bool()
+                  .get();
+  
+  private static final Phenotype medstmt =
+          new Phe("medstmt", "http://fhir.de/CodeSystem/bfarm/atc", "atc1", "atc2")
+                  .itemType(ItemType.MEDICATION_STATEMENT)
+                  .bool()
+                  .get();
+  
+  static Arguments a(Phenotype phe, UnaryOperator<Que> restriction, String... expected) {
+    return Arguments.of(phe, restriction, Set.of(expected));
+  }
+  
+  static Stream<Arguments> data() {
+    return Stream.of(
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-01"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0011-E-1",
+                    "HOSP-0012-E-1"),
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-02"), DateUtil.parse("2020-01-02"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0012-E-1",
+                    "HOSP-0014-E-1"),
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-02"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0011-E-1",
+                    "HOSP-0012-E-1",
+                    "HOSP-0014-E-1"),
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-03"), DateUtil.parse("2020-01-03"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0013-E-1",
+                    "HOSP-0014-E-1"),
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-03"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0011-E-1",
+                    "HOSP-0012-E-1",
+                    "HOSP-0013-E-1",
+                    "HOSP-0014-E-1"),
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.ge(DateUtil.parse("2020-01-03"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0013-E-1",
+                    "HOSP-0014-E-1",
+                    "HOSP-0015-E-1"),
+            a(
+                    medadm,
+                    q -> q.inc(medadm, Res.le(DateUtil.parse("2020-01-04"))),
+                    "HOSP-0004-E-1",
+                    "HOSP-0011-E-1",
+                    "HOSP-0012-E-1",
+                    "HOSP-0013-E-1",
+                    "HOSP-0014-E-1"),
+            
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-01"))),
+                    "HOSP-0031-E-1",
+                    "HOSP-0032-E-1"),
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-02"), DateUtil.parse("2020-01-02"))),
+                    "HOSP-0032-E-1",
+                    "HOSP-0034-E-1"),
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-02"))),
+                    "HOSP-0031-E-1",
+                    "HOSP-0032-E-1",
+                    "HOSP-0034-E-1"),
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-03"), DateUtil.parse("2020-01-03"))),
+                    "HOSP-0033-E-1",
+                    "HOSP-0034-E-1"),
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.geLe(DateUtil.parse("2020-01-01"), DateUtil.parse("2020-01-03"))),
+                    "HOSP-0031-E-1",
+                    "HOSP-0032-E-1",
+                    "HOSP-0033-E-1",
+                    "HOSP-0034-E-1"),
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.ge(DateUtil.parse("2020-01-03"))),
+                    "HOSP-0033-E-1",
+                    "HOSP-0034-E-1",
+                    "HOSP-0035-E-1"),
+            a(
+                    medstmt,
+                    q -> q.inc(medstmt, Res.le(DateUtil.parse("2020-01-04"))),
+                    "HOSP-0031-E-1",
+                    "HOSP-0032-E-1",
+                    "HOSP-0033-E-1",
+                    "HOSP-0034-E-1")
+    );
+  }
+  
+  @ParameterizedTest
+  @MethodSource("data")
+  void medicationAdministration(Phenotype phe, Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
+          throws InstantiationException {
+    ResultSet rs =
+            restrictions
+                    .apply(new Que(CONFIG, phe))
+                    .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/medication_time.sql")
+                    .execute();
+    assertEquals(expectedSubjectIds, rs.getSubjectIds());
+  }
+}

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
@@ -1,5 +1,7 @@
 package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import care.smith.top.model.ItemType;
 import care.smith.top.model.Phenotype;
 import care.smith.top.top_phenotypic_query.result.ResultSet;
@@ -7,16 +9,13 @@ import care.smith.top.top_phenotypic_query.util.DateUtil;
 import care.smith.top.top_phenotypic_query.util.builder.Phe;
 import care.smith.top.top_phenotypic_query.util.builder.Que;
 import care.smith.top.top_phenotypic_query.util.builder.Res;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class MedicationTimeTest {
   

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/MedicationTimeTest.java
@@ -82,8 +82,7 @@ public class MedicationTimeTest {
             q -> q.inc(medadm, Res.ge(DateUtil.parse("2020-01-03"))),
             "HOSP-0004-E-1",
             "HOSP-0013-E-1",
-            "HOSP-0014-E-1",
-            "HOSP-0015-E-1"),
+            "HOSP-0014-E-1"),
         a(
             medadm,
             q -> q.inc(medadm, Res.le(DateUtil.parse("2020-01-04"))),
@@ -134,8 +133,7 @@ public class MedicationTimeTest {
             medstmt,
             q -> q.inc(medstmt, Res.ge(DateUtil.parse("2020-01-03"))),
             "HOSP-0033-E-1",
-            "HOSP-0034-E-1",
-            "HOSP-0035-E-1"),
+            "HOSP-0034-E-1"),
         a(
             medstmt,
             q -> q.inc(medstmt, Res.le(DateUtil.parse("2020-01-04"))),

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
@@ -1,0 +1,86 @@
+package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
+
+import care.smith.top.model.ItemType;
+import care.smith.top.model.Phenotype;
+import care.smith.top.top_phenotypic_query.result.ResultSet;
+import care.smith.top.top_phenotypic_query.util.DateUtil;
+import care.smith.top.top_phenotypic_query.util.builder.Phe;
+import care.smith.top.top_phenotypic_query.util.builder.Que;
+import care.smith.top.top_phenotypic_query.util.builder.Res;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProcedureTest {
+
+  private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
+
+  private static final Phenotype sex = new Phe("sex").itemType(ItemType.SUBJECT_SEX).string().get();
+  private static final Phenotype male = new Phe("male").restriction(sex, Res.of("male")).get();
+  private static final Phenotype age = new Phe("age").itemType(ItemType.SUBJECT_AGE).number().get();
+  private static final Phenotype old = new Phe("old").restriction(age, Res.ge(60)).get();
+
+  private static final Phenotype proc =
+      new Phe("proc", "http://fhir.de/CodeSystem/bfarm/ops", "8-853.3", "8-855.71", "8-857.21")
+          .itemType(ItemType.PROCEDURE)
+          .bool()
+          .get();
+
+  static Arguments a(UnaryOperator<Que> restriction, String... expected) {
+    return Arguments.of(restriction, Set.of(expected));
+  }
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
+            "HOSP-0002-E2",
+            "HOSP-0003-E3"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2",
+            "HOSP-0003-E3"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
+            "HOSP-0004-E4"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
+                "HOSP-0001-E1",
+                "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4"),
+        a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
+        a(
+            q -> q.inc(proc, Res.le(DateUtil.parse("2026-04-05"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4",
+            "HOSP-0005-E5",
+            "HOSP-0006-E6"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  void procedure(Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
+      throws InstantiationException {
+    ResultSet rs =
+        restrictions
+            .apply(new Que(CONFIG, proc))
+            .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/procedure.sql")
+            .execute();
+    assertEquals(expectedSubjectIds, rs.getSubjectIds());
+  }
+}

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
@@ -1,5 +1,7 @@
 package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import care.smith.top.model.ItemType;
 import care.smith.top.model.Phenotype;
 import care.smith.top.top_phenotypic_query.result.ResultSet;
@@ -7,80 +9,77 @@ import care.smith.top.top_phenotypic_query.util.DateUtil;
 import care.smith.top.top_phenotypic_query.util.builder.Phe;
 import care.smith.top.top_phenotypic_query.util.builder.Que;
 import care.smith.top.top_phenotypic_query.util.builder.Res;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ProcedureTest {
-  
+
   private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
-  
+
   private static final Phenotype sex = new Phe("sex").itemType(ItemType.SUBJECT_SEX).string().get();
   private static final Phenotype male = new Phe("male").restriction(sex, Res.of("male")).get();
   private static final Phenotype age = new Phe("age").itemType(ItemType.SUBJECT_AGE).number().get();
   private static final Phenotype old = new Phe("old").restriction(age, Res.ge(60)).get();
-  
+
   private static final Phenotype proc =
-          new Phe("proc", "http://fhir.de/CodeSystem/bfarm/ops", "8-853.3", "8-855.71", "8-857.21")
-                  .itemType(ItemType.PROCEDURE)
-                  .bool()
-                  .get();
-  
+      new Phe("proc", "http://fhir.de/CodeSystem/bfarm/ops", "8-853.3", "8-855.71", "8-857.21")
+          .itemType(ItemType.PROCEDURE)
+          .bool()
+          .get();
+
   static Arguments a(UnaryOperator<Que> restriction, String... expected) {
     return Arguments.of(restriction, Set.of(expected));
   }
-  
+
   static Stream<Arguments> data() {
     return Stream.of(
-            a(
-                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
-                    "HOSP-0001-E1",
-                    "HOSP-0002-E2"),
-            a(
-                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
-                    "HOSP-0002-E2",
-                    "HOSP-0003-E3"),
-            a(
-                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
-                    "HOSP-0001-E1",
-                    "HOSP-0002-E2",
-                    "HOSP-0003-E3"),
-            a(
-                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
-                    "HOSP-0004-E4"),
-            a(
-                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
-                    "HOSP-0001-E1",
-                    "HOSP-0002-E2",
-                    "HOSP-0003-E3",
-                    "HOSP-0004-E4"),
-            a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
-            a(
-                    q -> q.inc(proc, Res.le(DateUtil.parse("2026-04-05"))),
-                    "HOSP-0001-E1",
-                    "HOSP-0002-E2",
-                    "HOSP-0003-E3",
-                    "HOSP-0004-E4",
-                    "HOSP-0005-E5",
-                    "HOSP-0006-E6"));
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
+            "HOSP-0002-E2",
+            "HOSP-0003-E3"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2",
+            "HOSP-0003-E3"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
+            "HOSP-0004-E4"),
+        a(
+            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4"),
+        a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
+        a(
+            q -> q.inc(proc, Res.le(DateUtil.parse("2026-04-05"))),
+            "HOSP-0001-E1",
+            "HOSP-0002-E2",
+            "HOSP-0003-E3",
+            "HOSP-0004-E4",
+            "HOSP-0005-E5",
+            "HOSP-0006-E6"));
   }
-  
+
   @ParameterizedTest
   @MethodSource("data")
   void procedure(Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
-          throws InstantiationException {
+      throws InstantiationException {
     ResultSet rs =
-            restrictions
-                    .apply(new Que(CONFIG, proc))
-                    .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/procedure.sql")
-                    .execute();
+        restrictions
+            .apply(new Que(CONFIG, proc))
+            .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/procedure.sql")
+            .execute();
     assertEquals(expectedSubjectIds, rs.getSubjectIds());
   }
 }

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
@@ -61,7 +61,8 @@ public class ProcedureTest {
             "HOSP-0002-E2",
             "HOSP-0003-E3",
             "HOSP-0004-E4"),
-        a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))),
+        a(
+            q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))),
             "HOSP-0003-E3",
             "HOSP-0005-E5",
             "HOSP-0007-E7"),

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
@@ -53,6 +53,7 @@ public class ProcedureTest {
             "HOSP-0003-E3"),
         a(
             q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
+            "HOSP-0003-E3",
             "HOSP-0004-E4"),
         a(
             q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
@@ -60,7 +61,10 @@ public class ProcedureTest {
             "HOSP-0002-E2",
             "HOSP-0003-E3",
             "HOSP-0004-E4"),
-        a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
+        a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))),
+            "HOSP-0003-E3",
+            "HOSP-0005-E5",
+            "HOSP-0007-E7"),
         a(
             q -> q.inc(proc, Res.le(DateUtil.parse("2026-04-05"))),
             "HOSP-0001-E1",

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
@@ -1,7 +1,5 @@
 package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import care.smith.top.model.ItemType;
 import care.smith.top.model.Phenotype;
 import care.smith.top.top_phenotypic_query.result.ResultSet;
@@ -9,77 +7,80 @@ import care.smith.top.top_phenotypic_query.util.DateUtil;
 import care.smith.top.top_phenotypic_query.util.builder.Phe;
 import care.smith.top.top_phenotypic_query.util.builder.Que;
 import care.smith.top.top_phenotypic_query.util.builder.Res;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ProcedureTest {
-
+  
   private static final String CONFIG = "config/Interpolar_Adapter_Test.yml";
-
+  
   private static final Phenotype sex = new Phe("sex").itemType(ItemType.SUBJECT_SEX).string().get();
   private static final Phenotype male = new Phe("male").restriction(sex, Res.of("male")).get();
   private static final Phenotype age = new Phe("age").itemType(ItemType.SUBJECT_AGE).number().get();
   private static final Phenotype old = new Phe("old").restriction(age, Res.ge(60)).get();
-
+  
   private static final Phenotype proc =
-      new Phe("proc", "http://fhir.de/CodeSystem/bfarm/ops", "8-853.3", "8-855.71", "8-857.21")
-          .itemType(ItemType.PROCEDURE)
-          .bool()
-          .get();
-
+          new Phe("proc", "http://fhir.de/CodeSystem/bfarm/ops", "8-853.3", "8-855.71", "8-857.21")
+                  .itemType(ItemType.PROCEDURE)
+                  .bool()
+                  .get();
+  
   static Arguments a(UnaryOperator<Que> restriction, String... expected) {
     return Arguments.of(restriction, Set.of(expected));
   }
-
+  
   static Stream<Arguments> data() {
     return Stream.of(
-        a(
-            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
-            "HOSP-0001-E1",
-            "HOSP-0002-E2"),
-        a(
-            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
-            "HOSP-0002-E2",
-            "HOSP-0003-E3"),
-        a(
-            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
-            "HOSP-0001-E1",
-            "HOSP-0002-E2",
-            "HOSP-0003-E3"),
-        a(
-            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
-            "HOSP-0004-E4"),
-        a(
-            q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
-            "HOSP-0001-E1",
-            "HOSP-0002-E2",
-            "HOSP-0003-E3",
-            "HOSP-0004-E4"),
-        a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
-        a(
-            q -> q.inc(proc, Res.le(DateUtil.parse("2026-04-05"))),
-            "HOSP-0001-E1",
-            "HOSP-0002-E2",
-            "HOSP-0003-E3",
-            "HOSP-0004-E4",
-            "HOSP-0005-E5",
-            "HOSP-0006-E6"));
+            a(
+                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-01"))),
+                    "HOSP-0001-E1",
+                    "HOSP-0002-E2"),
+            a(
+                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-02"), DateUtil.parse("2026-04-02"))),
+                    "HOSP-0002-E2",
+                    "HOSP-0003-E3"),
+            a(
+                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-02"))),
+                    "HOSP-0001-E1",
+                    "HOSP-0002-E2",
+                    "HOSP-0003-E3"),
+            a(
+                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-03"), DateUtil.parse("2026-04-03"))),
+                    "HOSP-0004-E4"),
+            a(
+                    q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
+                    "HOSP-0001-E1",
+                    "HOSP-0002-E2",
+                    "HOSP-0003-E3",
+                    "HOSP-0004-E4"),
+            a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),
+            a(
+                    q -> q.inc(proc, Res.le(DateUtil.parse("2026-04-05"))),
+                    "HOSP-0001-E1",
+                    "HOSP-0002-E2",
+                    "HOSP-0003-E3",
+                    "HOSP-0004-E4",
+                    "HOSP-0005-E5",
+                    "HOSP-0006-E6"));
   }
-
+  
   @ParameterizedTest
   @MethodSource("data")
   void procedure(Function<Que, Que> restrictions, Set<String> expectedSubjectIds)
-      throws InstantiationException {
+          throws InstantiationException {
     ResultSet rs =
-        restrictions
-            .apply(new Que(CONFIG, proc))
-            .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/procedure.sql")
-            .execute();
+            restrictions
+                    .apply(new Que(CONFIG, proc))
+                    .executeSqlFromResources("INTERPOLAR_DB_2/db.sql", "INTERPOLAR_DB_2/procedure.sql")
+                    .execute();
     assertEquals(expectedSubjectIds, rs.getSubjectIds());
   }
 }

--- a/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
+++ b/src/test/java/care/smith/top/top_phenotypic_query/tests/INTERPOLAR_DB_2/ProcedureTest.java
@@ -1,5 +1,7 @@
 package care.smith.top.top_phenotypic_query.tests.INTERPOLAR_DB_2;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import care.smith.top.model.ItemType;
 import care.smith.top.model.Phenotype;
 import care.smith.top.top_phenotypic_query.result.ResultSet;
@@ -7,16 +9,13 @@ import care.smith.top.top_phenotypic_query.util.DateUtil;
 import care.smith.top.top_phenotypic_query.util.builder.Phe;
 import care.smith.top.top_phenotypic_query.util.builder.Que;
 import care.smith.top.top_phenotypic_query.util.builder.Res;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ProcedureTest {
 
@@ -57,8 +56,8 @@ public class ProcedureTest {
             "HOSP-0004-E4"),
         a(
             q -> q.inc(proc, Res.geLe(DateUtil.parse("2026-04-01"), DateUtil.parse("2026-04-03"))),
-                "HOSP-0001-E1",
-                "HOSP-0002-E2",
+            "HOSP-0001-E1",
+            "HOSP-0002-E2",
             "HOSP-0003-E3",
             "HOSP-0004-E4"),
         a(q -> q.inc(proc, Res.ge(DateUtil.parse("2026-04-07"))), "HOSP-0005-E5", "HOSP-0007-E7"),

--- a/src/test/resources/INTERPOLAR_DB_2/condition.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/condition.sql
@@ -1,0 +1,33 @@
+INSERT INTO db2dataprocessor_out.v_patient (pat_id, pat_birthdate, pat_gender)
+VALUES ('HOSP-0001', '1960-01-01', 'female'),
+       ('HOSP-0002', '1960-01-01', 'female'),
+       ('HOSP-0003', '1980-01-01', 'male'),
+       ('HOSP-0004', '2000-01-01', 'male');
+
+INSERT INTO db2dataprocessor_out.v_encounter (enc_id, enc_patient_ref, enc_class_code, enc_period_start,
+                                              enc_period_end)
+VALUES ('HOSP-0001-E-11', 'Patient/HOSP-0001', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0002-E-21', 'Patient/HOSP-0001', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0003-E-22', 'Patient/HOSP-0002', 'IMP', '2018-01-01', '2018-02-01'),
+       ('HOSP-0004-E-31', 'Patient/HOSP-0003', 'IMP', '2019-01-01', '2019-02-01'),
+       ('HOSP-0005-E-41', 'Patient/HOSP-0004', 'AMB', '2020-01-01', '2020-02-01'),
+       ('HOSP-0006-E-42', 'Patient/HOSP-0004', 'IMP', '2017-01-01', '2017-02-01');
+
+
+INSERT INTO db2dataprocessor_out.v_condition (con_id,
+                                              con_encounter_calculated_ref,
+                                              con_patient_ref,
+                                              con_code_system,
+                                              con_code_code,
+                                              con_onsetperiod_start,
+                                              con_onsetperiod_end,
+                                              con_onsetdatetime,
+                                              con_recordeddate)
+VALUES ('HOSP-0001-E11-C1', 'Encounter/HOSP-0001-E11', 'Patient/HOSP-0001', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
+       ('HOSP-0001-E11-C2', 'Encounter/HOSP-0001-E11', 'Patient/HOSP-0001', 'http://snomed.info/sct', '135816001', null, null, '2026-04-21', null),
+       ('HOSP-0002-E21-C1', 'Encounter/HOSP-0002-E21', 'Patient/HOSP-0002', 'http://snomed.info/sct', '258157001', '2026-04-21 13:00:00', '026-04-21 15:00:00', null, null),
+       ('HOSP-0002-E22-C2', 'Encounter/HOSP-0002-E22', 'Patient/HOSP-0002', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
+       ('HOSP-0003-E31-C1', 'Encounter/HOSP-0003-E31', 'Patient/HOSP-0003', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
+       ('HOSP-0003-E31-C2', 'Encounter/HOSP-0003-E31', 'Patient/HOSP-0003', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
+       ('HOSP-0004-E41-C1', 'Encounter/HOSP-0004-E41', 'Patient/HOSP-0004', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
+       ('HOSP-0004-E42-C2', 'Encounter/HOSP-0004-E42', 'Patient/HOSP-0004', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null);

--- a/src/test/resources/INTERPOLAR_DB_2/condition.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/condition.sql
@@ -1,33 +1,30 @@
 INSERT INTO db2dataprocessor_out.v_patient (pat_id, pat_birthdate, pat_gender)
 VALUES ('HOSP-0001', '1960-01-01', 'female'),
        ('HOSP-0002', '1960-01-01', 'female'),
-       ('HOSP-0003', '1980-01-01', 'male'),
-       ('HOSP-0004', '2000-01-01', 'male');
+       ('HOSP-0003', '1980-01-01', 'male'  ),
+       ('HOSP-0004', '2000-01-01', 'male'  ),
+       ('HOSP-0005', '2001-01-01', 'female'),
+       ('HOSP-0006', '2002-01-01', 'female'),
+       ('HOSP-0007', '2003-01-01', 'male'  ),
+       ('HOSP-0008', '2004-01-01', 'male'  );
 
-INSERT INTO db2dataprocessor_out.v_encounter (enc_id, enc_patient_ref, enc_class_code, enc_period_start,
-                                              enc_period_end)
-VALUES ('HOSP-0001-E-11', 'Patient/HOSP-0001', 'IMP', '2017-01-01', '2017-02-01'),
-       ('HOSP-0002-E-21', 'Patient/HOSP-0001', 'IMP', '2017-01-01', '2017-02-01'),
-       ('HOSP-0003-E-22', 'Patient/HOSP-0002', 'IMP', '2018-01-01', '2018-02-01'),
-       ('HOSP-0004-E-31', 'Patient/HOSP-0003', 'IMP', '2019-01-01', '2019-02-01'),
-       ('HOSP-0005-E-41', 'Patient/HOSP-0004', 'AMB', '2020-01-01', '2020-02-01'),
-       ('HOSP-0006-E-42', 'Patient/HOSP-0004', 'IMP', '2017-01-01', '2017-02-01');
+INSERT INTO db2dataprocessor_out.v_encounter (enc_id, enc_patient_ref, enc_class_code, enc_period_start, enc_period_end)
+VALUES ('HOSP-0001-E1', 'Patient/HOSP-0001', 'IMP', '2026-04-01', '2026-04-11'),
+       ('HOSP-0002-E2', 'Patient/HOSP-0002', 'AMB', '2026-04-02', '2026-04-12'),
+       ('HOSP-0003-E3', 'Patient/HOSP-0003', 'IMP', '2026-04-03', '2026-04-13'),
+       ('HOSP-0004-E4', 'Patient/HOSP-0004', 'AMB', '2026-04-04', '2026-04-14'),
+       ('HOSP-0005-E5', 'Patient/HOSP-0005', 'IMP', '2026-04-05', '2026-04-15'),
+       ('HOSP-0006-E6', 'Patient/HOSP-0006', 'AMB', '2026-04-06', '2026-04-16'),
+       ('HOSP-0007-E7', 'Patient/HOSP-0007', 'IMP', '2026-04-07', '2026-04-17'),
+       ('HOSP-0008-E8', 'Patient/HOSP-0008', 'AMB', '2026-04-08', '2026-04-18');
 
 
-INSERT INTO db2dataprocessor_out.v_condition (con_id,
-                                              con_encounter_calculated_ref,
-                                              con_patient_ref,
-                                              con_code_system,
-                                              con_code_code,
-                                              con_onsetperiod_start,
-                                              con_onsetperiod_end,
-                                              con_onsetdatetime,
-                                              con_recordeddate)
-VALUES ('HOSP-0001-E11-C1', 'Encounter/HOSP-0001-E11', 'Patient/HOSP-0001', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
-       ('HOSP-0001-E11-C2', 'Encounter/HOSP-0001-E11', 'Patient/HOSP-0001', 'http://snomed.info/sct', '135816001', null, null, '2026-04-21', null),
-       ('HOSP-0002-E21-C1', 'Encounter/HOSP-0002-E21', 'Patient/HOSP-0002', 'http://snomed.info/sct', '258157001', '2026-04-21 13:00:00', '026-04-21 15:00:00', null, null),
-       ('HOSP-0002-E22-C2', 'Encounter/HOSP-0002-E22', 'Patient/HOSP-0002', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
-       ('HOSP-0003-E31-C1', 'Encounter/HOSP-0003-E31', 'Patient/HOSP-0003', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
-       ('HOSP-0003-E31-C2', 'Encounter/HOSP-0003-E31', 'Patient/HOSP-0003', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
-       ('HOSP-0004-E41-C1', 'Encounter/HOSP-0004-E41', 'Patient/HOSP-0004', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null),
-       ('HOSP-0004-E42-C2', 'Encounter/HOSP-0004-E42', 'Patient/HOSP-0004', 'http://snomed.info/sct', '438949009', '2000-01-01', null, null, null);
+INSERT INTO db2dataprocessor_out.v_condition (con_id, con_encounter_calculated_ref, con_patient_ref, con_code_system, con_code_code, con_onsetperiod_start, con_onsetperiod_end, con_onsetdatetime, con_recordeddate)
+VALUES ('HOSP-0001-E1-C1', 'Encounter/HOSP-0001-E1', 'Patient/HOSP-0001', 'http://snomed.info/sct', '135816001', null,         null,         null,         null        ),
+       ('HOSP-0002-E2-C2', 'Encounter/HOSP-0002-E2', 'Patient/HOSP-0002', 'http://snomed.info/sct', '135816001', null,         null,         null,         '2026-04-01'),
+       ('HOSP-0003-E3-C3', 'Encounter/HOSP-0003-E3', 'Patient/HOSP-0003', 'http://snomed.info/sct', '258157001', null,         null,         '2026-04-02', null        ),
+       ('HOSP-0004-E4-C4', 'Encounter/HOSP-0004-E4', 'Patient/HOSP-0004', 'http://snomed.info/sct', '135816001', null,         '2026-04-03', null,         null        ),
+       ('HOSP-0005-E5-C5', 'Encounter/HOSP-0005-E5', 'Patient/HOSP-0005', 'http://snomed.info/sct', '438949009', '2026-04-04', null,         null,         null        ),
+       ('HOSP-0006-E6-C6', 'Encounter/HOSP-0006-E6', 'Patient/HOSP-0006', 'http://snomed.info/sct', '135816001', '2026-04-05', '2026-04-06', null,         null        ),
+       ('HOSP-0007-E7-C7', 'Encounter/HOSP-0007-E7', 'Patient/HOSP-0007', 'http://snomed.info/sct', '135816001', '2026-04-07', '2026-04-08', '2026-04-09', '2026-04-05'),
+       ('HOSP-0008-E8-C8', 'Encounter/HOSP-0008-E8', 'Patient/HOSP-0008', 'http://snomed.info/sct', '258157001', '2026-04-11', '2026-04-05', null,         null        );

--- a/src/test/resources/INTERPOLAR_DB_2/db.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/db.sql
@@ -41,6 +41,9 @@ CREATE TABLE db2dataprocessor_out."v_condition"
     con_code_code                varchar NULL,
     con_code_display             varchar NULL,
     con_code_text                varchar NULL,
+    con_onsetperiod_start        timestamp NULL,
+    con_onsetperiod_end          timestamp NULL,
+    con_onsetdatetime            timestamp NULL,
     con_recordeddate             timestamp NULL,
     PRIMARY KEY (con_id)
 );

--- a/src/test/resources/INTERPOLAR_DB_2/db.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/db.sql
@@ -10,11 +10,11 @@ CREATE TABLE db2dataprocessor_out.v_patient
 
 CREATE TABLE db2dataprocessor_out.v_encounter
 (
-    enc_id                      varchar NOT NULL,
-    enc_patient_ref             varchar NULL,
-    enc_class_code              varchar NULL,
-    enc_period_start            timestamp NULL,
-    enc_period_end              timestamp NULL,
+    enc_id           varchar NOT NULL,
+    enc_patient_ref  varchar NULL,
+    enc_class_code   varchar NULL,
+    enc_period_start timestamp NULL,
+    enc_period_end   timestamp NULL,
     PRIMARY KEY (enc_id)
 );
 
@@ -53,6 +53,8 @@ CREATE TABLE db2dataprocessor_out.v_procedure
     proc_code_system              varchar NULL,
     proc_code_code                varchar NULL,
     proc_performeddatetime        timestamp NULL,
+    proc_performedperiod_start    timestamp NULL,
+    proc_performedperiod_end      timestamp NULL,
     PRIMARY KEY (proc_id)
 );
 
@@ -70,6 +72,8 @@ CREATE TABLE db2dataprocessor_out.v_medicationadministration
     medadm_encounter_calculated_ref varchar NULL,
     medadm_patient_ref              varchar NULL,
     medadm_effectivedatetime        timestamp NULL,
+    medadm_effectiveperiod_start    timestamp NULL,
+    medadm_effectiveperiod_end      timestamp NULL,
     medadm_medicationreference_ref  varchar NULL,
     PRIMARY KEY (medadm_id)
 );
@@ -81,6 +85,8 @@ CREATE TABLE db2dataprocessor_out.v_medicationstatement
     medstat_patient_ref              varchar NULL,
     medstat_medicationreference_ref  varchar NULL,
     medstat_effectivedatetime        timestamp NULL,
+    medstat_effectiveperiod_start    timestamp NULL,
+    medstat_effectiveperiod_end      timestamp NULL,
     PRIMARY KEY (medstat_id)
 );
 

--- a/src/test/resources/INTERPOLAR_DB_2/db.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/db.sql
@@ -31,7 +31,7 @@ CREATE TABLE db2dataprocessor_out.v_observation
     PRIMARY KEY (obs_id, obs_code_system, obs_code_code)
 );
 
-CREATE TABLE db2dataprocessor_out."v_condition"
+CREATE TABLE db2dataprocessor_out.v_condition
 (
     con_id                       varchar NOT NULL,
     con_encounter_calculated_ref varchar NULL,

--- a/src/test/resources/INTERPOLAR_DB_2/medication.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/medication.sql
@@ -43,13 +43,14 @@ VALUES ('Medication-1', 'http://fhir.de/CodeSystem/bfarm/atc', 'atc1'),
        ('Medication-2', 'http://fhir.de/CodeSystem/bfarm/atc', 'atc2');
 
 INSERT INTO db2dataprocessor_out.v_medicationadministration (medadm_id, medadm_encounter_calculated_ref, medadm_patient_ref,
-                                             medadm_effectivedatetime, medadm_medicationreference_ref)
-VALUES ('HOSP-0011-E-1-MA-1', 'Encounter/HOSP-0011-E-1', 'Patient/HOSP-0011', '2020-01-01', 'Medication/Medication-1'),
-       ('HOSP-0012-E-1-MA-1', 'Encounter/HOSP-0012-E-1', 'Patient/HOSP-0012', '2020-01-01', 'Medication/Medication-1'),
-       ('HOSP-0013-E-1-MA-1', 'Encounter/HOSP-0013-E-1', 'Patient/HOSP-0013', '2020-01-01', 'Medication/Medication-1'),
-       ('HOSP-0014-E-1-MA-1', 'Encounter/HOSP-0014-E-1', 'Patient/HOSP-0014', '2020-01-01', 'Medication/Medication-1'),
-       ('HOSP-0015-E-1-MA-1', 'Encounter/HOSP-0015-E-1', 'Patient/HOSP-0015', '2019-01-01', 'Medication/Medication-1'),
-       ('HOSP-0004-E-1-MA-1', 'Encounter/HOSP-0004-E-1', 'Patient/HOSP-0004', '2021-01-01', 'Medication/Medication-2');
+                                             medadm_effectivedatetime, medadm_effectiveperiod_start, medadm_effectiveperiod_end,
+                                                             medadm_medicationreference_ref)
+VALUES ('HOSP-0011-E-1-MA-1', 'Encounter/HOSP-0011-E-1', 'Patient/HOSP-0011', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0012-E-1-MA-1', 'Encounter/HOSP-0012-E-1', 'Patient/HOSP-0012', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0013-E-1-MA-1', 'Encounter/HOSP-0013-E-1', 'Patient/HOSP-0013', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0014-E-1-MA-1', 'Encounter/HOSP-0014-E-1', 'Patient/HOSP-0014', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0015-E-1-MA-1', 'Encounter/HOSP-0015-E-1', 'Patient/HOSP-0015', '2019-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0004-E-1-MA-1', 'Encounter/HOSP-0004-E-1', 'Patient/HOSP-0004', '2021-01-01', null, null, 'Medication/Medication-2');
 
 INSERT INTO db2dataprocessor_out.v_medicationrequest (medreq_id, medreq_encounter_calculated_ref, medreq_patient_ref,
                                       medreq_authoredon, medreq_medicationreference_ref)
@@ -60,14 +61,9 @@ VALUES ('HOSP-0021-E-1-MR-1', 'Encounter/HOSP-0021-E-1', 'Patient/HOSP-0021', '2
        ('HOSP-0025-E-1-MR-1', 'Encounter/HOSP-0025-E-1', 'Patient/HOSP-0025', '2019-01-01', 'Medication/Medication-1');
 
 INSERT INTO db2dataprocessor_out.v_medicationstatement (medstat_id, medstat_encounter_calculated_ref, medstat_patient_ref,
-                                        medstat_effectivedatetime, medstat_medicationreference_ref)
-VALUES ('HOSP-0031-E-1-MS-1', 'Encounter/HOSP-0031-E-1', 'Patient/HOSP-0031', '2020-01-01',
-        'Medication/Medication-1'),
-       ('HOSP-0032-E-1-MS-1', 'Encounter/HOSP-0032-E-1', 'Patient/HOSP-0032', '2020-01-01',
-        'Medication/Medication-1'),
-       ('HOSP-0033-E-1-MS-1', 'Encounter/HOSP-0033-E-1', 'Patient/HOSP-0033', '2020-01-01',
-        'Medication/Medication-1'),
-       ('HOSP-0034-E-1-MS-1', 'Encounter/HOSP-0034-E-1', 'Patient/HOSP-0034', '2020-01-01',
-        'Medication/Medication-1'),
-       ('HOSP-0035-E-1-MS-1', 'Encounter/HOSP-0035-E-1', 'Patient/HOSP-0035', '2019-01-01',
-        'Medication/Medication-1');
+                                        medstat_effectivedatetime, medstat_effectiveperiod_start, medstat_effectiveperiod_end, medstat_medicationreference_ref)
+VALUES ('HOSP-0031-E-1-MS-1', 'Encounter/HOSP-0031-E-1', 'Patient/HOSP-0031', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0032-E-1-MS-1', 'Encounter/HOSP-0032-E-1', 'Patient/HOSP-0032', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0033-E-1-MS-1', 'Encounter/HOSP-0033-E-1', 'Patient/HOSP-0033', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0034-E-1-MS-1', 'Encounter/HOSP-0034-E-1', 'Patient/HOSP-0034', '2020-01-01', null, null, 'Medication/Medication-1'),
+       ('HOSP-0035-E-1-MS-1', 'Encounter/HOSP-0035-E-1', 'Patient/HOSP-0035', '2019-01-01', null, null, 'Medication/Medication-1');

--- a/src/test/resources/INTERPOLAR_DB_2/medication_time.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/medication_time.sql
@@ -1,0 +1,57 @@
+INSERT INTO db2dataprocessor_out.v_patient (pat_id, pat_birthdate, pat_gender)
+VALUES ('HOSP-0011', '2001-01-01', 'male'  ),
+       ('HOSP-0012', '2001-01-01', 'female'),
+       ('HOSP-0013', '1951-01-01', 'male'  ),
+       ('HOSP-0014', '1951-01-01', 'female'),
+       ('HOSP-0015', '1951-01-01', 'male'  ),
+
+       ('HOSP-0021', '2002-01-01', 'male'  ),
+       ('HOSP-0022', '2002-01-01', 'female'),
+       ('HOSP-0023', '1952-01-01', 'male'  ),
+       ('HOSP-0024', '1952-01-01', 'female'),
+       ('HOSP-0025', '1952-01-01', 'male'  ),
+
+       ('HOSP-0031', '2003-01-01', 'male'  ),
+       ('HOSP-0032', '2003-01-01', 'female'),
+       ('HOSP-0033', '1953-01-01', 'male'  ),
+       ('HOSP-0034', '1953-01-01', 'female'),
+       ('HOSP-0035', '1953-01-01', 'male'  ),
+
+       ('HOSP-0004', '1940-01-03', 'male'  );
+
+INSERT INTO db2dataprocessor_out.v_encounter (enc_id, enc_patient_ref, enc_class_code, enc_period_start, enc_period_end)
+VALUES ('HOSP-0011-E-1', 'Patient/HOSP-0011', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0012-E-1', 'Patient/HOSP-0012', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0013-E-1', 'Patient/HOSP-0013', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0014-E-1', 'Patient/HOSP-0014', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0015-E-1', 'Patient/HOSP-0015', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0021-E-1', 'Patient/HOSP-0021', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0022-E-1', 'Patient/HOSP-0022', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0023-E-1', 'Patient/HOSP-0023', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0024-E-1', 'Patient/HOSP-0024', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0025-E-1', 'Patient/HOSP-0025', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0031-E-1', 'Patient/HOSP-0031', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0032-E-1', 'Patient/HOSP-0032', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0033-E-1', 'Patient/HOSP-0033', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0034-E-1', 'Patient/HOSP-0034', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0035-E-1', 'Patient/HOSP-0035', 'IMP', '2017-01-01', '2017-02-01'),
+       ('HOSP-0004-E-1', 'Patient/HOSP-0004', 'IMP', '2017-01-01', '2017-02-01');
+
+INSERT INTO db2dataprocessor_out.v_medication (med_id, med_code_system, med_code_code)
+VALUES ('Medication-1', 'http://fhir.de/CodeSystem/bfarm/atc', 'atc1'),
+       ('Medication-2', 'http://fhir.de/CodeSystem/bfarm/atc', 'atc2');
+
+INSERT INTO db2dataprocessor_out.v_medicationadministration (medadm_id, medadm_encounter_calculated_ref, medadm_patient_ref, medadm_effectivedatetime, medadm_effectiveperiod_start, medadm_effectiveperiod_end, medadm_medicationreference_ref)
+VALUES ('HOSP-0011-E-1-MA-1', 'Encounter/HOSP-0011-E-1', 'Patient/HOSP-0011', '2020-01-01', null,         null,         'Medication/Medication-1'),
+       ('HOSP-0012-E-1-MA-1', 'Encounter/HOSP-0012-E-1', 'Patient/HOSP-0012', null,         '2020-01-01', '2020-01-02', 'Medication/Medication-2'),
+       ('HOSP-0013-E-1-MA-1', 'Encounter/HOSP-0013-E-1', 'Patient/HOSP-0013', null,         '2020-01-03', '2020-01-04', 'Medication/Medication-1'),
+       ('HOSP-0014-E-1-MA-1', 'Encounter/HOSP-0014-E-1', 'Patient/HOSP-0014', '2020-01-01', '2020-01-02', '2020-01-03', 'Medication/Medication-2'),
+       ('HOSP-0015-E-1-MA-1', 'Encounter/HOSP-0015-E-1', 'Patient/HOSP-0015', null,         null,         null,         'Medication/Medication-1'),
+       ('HOSP-0004-E-1-MA-1', 'Encounter/HOSP-0004-E-1', 'Patient/HOSP-0004', null,         '2020-01-01', null,         'Medication/Medication-2');
+
+INSERT INTO db2dataprocessor_out.v_medicationstatement (medstat_id, medstat_encounter_calculated_ref, medstat_patient_ref, medstat_effectivedatetime, medstat_effectiveperiod_start, medstat_effectiveperiod_end, medstat_medicationreference_ref)
+VALUES ('HOSP-0031-E-1-MS-1', 'Encounter/HOSP-0031-E-1', 'Patient/HOSP-0031', '2020-01-01', null,         null,          'Medication/Medication-1'),
+       ('HOSP-0032-E-1-MS-1', 'Encounter/HOSP-0032-E-1', 'Patient/HOSP-0032', null,         '2020-01-01', '2020-01-02',  'Medication/Medication-2'),
+       ('HOSP-0033-E-1-MS-1', 'Encounter/HOSP-0033-E-1', 'Patient/HOSP-0033', null,         '2020-01-03', '2020-01-04',  'Medication/Medication-1'),
+       ('HOSP-0034-E-1-MS-1', 'Encounter/HOSP-0034-E-1', 'Patient/HOSP-0034', '2020-01-01', '2020-01-02', '2020-01-03',  'Medication/Medication-2'),
+       ('HOSP-0035-E-1-MS-1', 'Encounter/HOSP-0035-E-1', 'Patient/HOSP-0035', null,         null,         null,          'Medication/Medication-1');

--- a/src/test/resources/INTERPOLAR_DB_2/meld.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/meld.sql
@@ -30,10 +30,10 @@ INSERT INTO db2dataprocessor_out.v_medicationadministration (medadm_id, medadm_e
 VALUES ('HOSP-0003-E-33-MA-1', 'Encounter/HOSP-0003-E-33', 'Patient/HOSP-0003', '2020-01-01',
         'Medication/Medication-1');
 
-INSERT INTO db2dataprocessor_out.v_procedure (proc_id, proc_encounter_calculated_ref, proc_patient_ref, proc_code_system, proc_code_code, proc_performeddatetime)
-VALUES ('HOSP-0004-E-44-P-441', 'Encounter/HOSP-0004-E-44', 'Patient/HOSP-0004', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853', current_date - 8),
-       ('HOSP-0004-E-44-P-442', 'Encounter/HOSP-0004-E-44', 'Patient/HOSP-0004', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853', current_date - 6),
-       ('HOSP-0008-E-88-P-881', 'Encounter/HOSP-0008-E-88', 'Patient/HOSP-0008', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853', current_date - 6);
+INSERT INTO db2dataprocessor_out.v_procedure (proc_id, proc_encounter_calculated_ref, proc_patient_ref, proc_code_system, proc_code_code, proc_performeddatetime, proc_performedperiod_start, proc_performedperiod_end)
+VALUES ('HOSP-0004-E-44-P-441', 'Encounter/HOSP-0004-E-44', 'Patient/HOSP-0004', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853', current_date - 8, null, null),
+       ('HOSP-0004-E-44-P-442', 'Encounter/HOSP-0004-E-44', 'Patient/HOSP-0004', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853', current_date - 6, null, null),
+       ('HOSP-0008-E-88-P-881', 'Encounter/HOSP-0008-E-88', 'Patient/HOSP-0008', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853', current_date - 6, null, null);
 
 INSERT INTO db2dataprocessor_out.v_observation (obs_id, obs_encounter_calculated_ref, obs_patient_ref, obs_code_system, obs_code_code,
                                 obs_effectivedatetime, obs_valuequantity_value)

--- a/src/test/resources/INTERPOLAR_DB_2/procedure.sql
+++ b/src/test/resources/INTERPOLAR_DB_2/procedure.sql
@@ -1,0 +1,30 @@
+INSERT INTO db2dataprocessor_out.v_patient (pat_id, pat_birthdate, pat_gender)
+VALUES ('HOSP-0001', '1960-01-01', 'female'),
+       ('HOSP-0002', '1960-01-01', 'female'),
+       ('HOSP-0003', '1980-01-01', 'male'  ),
+       ('HOSP-0004', '2000-01-01', 'male'  ),
+       ('HOSP-0005', '2001-01-01', 'female'),
+       ('HOSP-0006', '2002-01-01', 'female'),
+       ('HOSP-0007', '2003-01-01', 'male'  ),
+       ('HOSP-0008', '2004-01-01', 'male'  );
+
+INSERT INTO db2dataprocessor_out.v_encounter (enc_id, enc_patient_ref, enc_class_code, enc_period_start, enc_period_end)
+VALUES ('HOSP-0001-E1', 'Patient/HOSP-0001', 'IMP', '2026-04-01', '2026-04-11'),
+       ('HOSP-0002-E2', 'Patient/HOSP-0002', 'AMB', '2026-04-02', '2026-04-12'),
+       ('HOSP-0003-E3', 'Patient/HOSP-0003', 'IMP', '2026-04-03', '2026-04-13'),
+       ('HOSP-0004-E4', 'Patient/HOSP-0004', 'AMB', '2026-04-04', '2026-04-14'),
+       ('HOSP-0005-E5', 'Patient/HOSP-0005', 'IMP', '2026-04-05', '2026-04-15'),
+       ('HOSP-0006-E6', 'Patient/HOSP-0006', 'AMB', '2026-04-06', '2026-04-16'),
+       ('HOSP-0007-E7', 'Patient/HOSP-0007', 'IMP', '2026-04-07', '2026-04-17'),
+       ('HOSP-0008-E8', 'Patient/HOSP-0008', 'AMB', '2026-04-08', '2026-04-18');
+
+
+INSERT INTO db2dataprocessor_out.v_procedure (proc_id, proc_encounter_calculated_ref, proc_patient_ref, proc_code_system, proc_code_code, proc_performedperiod_start, proc_performedperiod_end, proc_performeddatetime)
+VALUES ('HOSP-0001-E1-C1', 'Encounter/HOSP-0001-E1', 'Patient/HOSP-0001', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853.3',  null,         null,         '2026-04-01'),
+       ('HOSP-0002-E2-C2', 'Encounter/HOSP-0002-E2', 'Patient/HOSP-0002', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853.3',  '2026-04-01', '2026-04-02', null        ),
+       ('HOSP-0003-E3-C3', 'Encounter/HOSP-0003-E3', 'Patient/HOSP-0003', 'http://fhir.de/CodeSystem/bfarm/ops', '8-855.71', '2026-04-02', null,         '2026-04-02'),
+       ('HOSP-0004-E4-C4', 'Encounter/HOSP-0004-E4', 'Patient/HOSP-0004', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853.3',  '2026-04-03', '2026-04-03', null        ),
+       ('HOSP-0005-E5-C5', 'Encounter/HOSP-0005-E5', 'Patient/HOSP-0005', 'http://fhir.de/CodeSystem/bfarm/ops', '8-857.21', '2026-04-04', null,         null        ),
+       ('HOSP-0006-E6-C6', 'Encounter/HOSP-0006-E6', 'Patient/HOSP-0006', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853.3',  '2026-04-05', '2026-04-06', null        ),
+       ('HOSP-0007-E7-C7', 'Encounter/HOSP-0007-E7', 'Patient/HOSP-0007', 'http://fhir.de/CodeSystem/bfarm/ops', '8-853.3',  '2026-04-07', '2026-04-08', '2026-04-09'),
+       ('HOSP-0008-E8-C8', 'Encounter/HOSP-0008-E8', 'Patient/HOSP-0008', 'http://fhir.de/CodeSystem/bfarm/ops', '8-855.71', '2026-04-11', '2026-04-05', null        );


### PR DESCRIPTION
This PR completes and extends time-based queries in the INTERPOLAR default adapter.
Tests are adapted, and some queries have been optimized.
This PR resolves #140.